### PR TITLE
updated Amazon SDK to 1.5.2 and removed transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,29 +113,8 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.29</version>
+            <version>1.5.2</version>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.1</version>
-        </dependency>
-
 
        <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
After debugging connection problems with ant upload of 2GB file, I've finally updated Amazon SDK and it works now.

I've also removed transitive dependencies as they are not required (and sdk version update failed with them)
