### PR TITLE
S3Get doesn't close the S3 TransferManager which causes leaked threads

### DIFF
--- a/src/main/it/corley/ant/S3GetTask.java
+++ b/src/main/it/corley/ant/S3GetTask.java
@@ -59,8 +59,9 @@ public class S3GetTask extends AWSTask {
 
   private void downloadFile(GetObjectRequest request, File outputFile) {
     log(String.format("Downloading '%s/%s' to '%s'", request.getBucketName(), request.getKey(), outputFile.getName()), Project.MSG_INFO);
+    TransferManager transferManager = null;
     try {
-      TransferManager transferManager = getTransferManager();
+      transferManager = getTransferManager();
       Download download = transferManager.download(request, outputFile);
       download.addProgressListener(getProgressListener());
       download.waitForCompletion();
@@ -68,6 +69,10 @@ public class S3GetTask extends AWSTask {
       log("Download interrupted");
       log(e.getMessage());
       throw new BuildException(e);
+    } finally {
+      if (transferManager != null) {
+        transferManager.shutdownNow();
+      }
     }
   }
 


### PR DESCRIPTION
When using the S3GetTask from groovy, the JVM will never exit since aws TransferManager creates a daemon thread. Pullreq fixes this (in a slightly clunky way)
